### PR TITLE
Various fixes and default changes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,7 +39,6 @@ oiofs_mountpoint_default_ignore_flush: true
 oiofs_mountpoint_default_log_level: 'NOTICE'  # 'NOTICE' < 'INFO' < 'DEBUG'
 oiofs_mountpoint_default_max_packed_chunks: 10
 oiofs_mountpoint_default_max_redis_connections: 30
-oiofs_mountpoint_default_recovery_cache_directory: '/mnt/oiofs-recover'
 oiofs_mountpoint_default_redis_sentinel_name: '{{ oiofs_mountpoint_default_namespace }}-master-1'
 oiofs_mountpoint_default_redis_sentinel_cluster: []
 oiofs_mountpoint_default_retry_delay: 500

--- a/tasks/mountpoint_absent.yml
+++ b/tasks/mountpoint_absent.yml
@@ -8,7 +8,7 @@
 
 - name: 'oiofs: Remove mountpoint as a gridinit service'
   include_role:
-    name: ansible-role-openio-gridinit
+    name: gridinit
   vars:
     - openio_gridinit_services:
       - name: "oiofs-{{ mountpoint_id }}"

--- a/tasks/mountpoint_present.yml
+++ b/tasks/mountpoint_present.yml
@@ -43,10 +43,11 @@
     group: root
     state: directory
     mode: 0750
+  when: mountpoint.recovery_cache_directory is defined
 
 - name: 'oiofs: Setup mountpoint as a gridinit service'
   include_role:
-    name: ansible-role-openio-gridinit
+    name: gridinit
   vars:
     - openio_gridinit_services:
       - name: "oiofs-{{ mountpoint_id }}"

--- a/templates/oiofs.cfg.j2
+++ b/templates/oiofs.cfg.j2
@@ -2,19 +2,20 @@
 {% if mountpoint.stats_server is defined %}
     "stats_server": "{{ mountpoint.stats_server }}",
 {% endif %}
-
     "attributes_timeout": {{ mountpoint.attributes_timeout | default(oiofs_mountpoint_default_attributes_timeout) }},
-    "auto_retry": {{ mountpoint.auto_retry | default(oiofs_mountpoint_default_auto_retry) }},
-    "cache_asynchronous": {{ mountpoint.cache_asynchronous | default(oiofs_mountpoint_default_cache_asynchronous) }},
+    "auto_retry": {{ mountpoint.auto_retry | default(oiofs_mountpoint_default_auto_retry) | lower }},
+    "cache_asynchronous": {{ mountpoint.cache_asynchronous | default(oiofs_mountpoint_default_cache_asynchronous) | lower }},
     "cache_directory": "{{ mountpoint.cache_directory | default(oiofs_mountpoint_default_cache_directory) }}",
     "cache_size": {{ mountpoint.cache_size_bytes | default(oiofs_mountpoint_default_cache_size_bytes) }},
     "cache_size_on_flush": {{ mountpoint.cache_size_on_flush_bytes | default(oiofs_mountpoint_default_cache_size_on_flush_bytes) }},
     "cache_timeout": {{ mountpoint.cache_timeout | default(oiofs_mountpoint_default_cache_timeout) }},
-    "ignore_flush": {{ mountpoint.ignore_flush | default(oiofs_mountpoint_default_ignore_flush) }},
+    "ignore_flush": {{ mountpoint.ignore_flush | default(oiofs_mountpoint_default_ignore_flush) | lower }},
     "log_level": "{{ mountpoint.log_level | default(oiofs_mountpoint_default_log_level) }}",
     "max_packed_chunks": {{ mountpoint.max_packed_chunks | default(oiofs_mountpoint_default_max_packed_chunks) }},
     "max_redis_connections": {{ mountpoint.max_redis_connections | default(oiofs_mountpoint_default_max_redis_connections) }},
-    "recovery_cache_directory": {{ mountpoint.recovery_cache_directory | default(oiofs_mountpoint_default_recovery_cache_directory) }},
+{% if mountpoint.recovery_cache_directory is defined %}
+    "recovery_cache_directory": "{{ mountpoint.recovery_cache_directory }}",
+{% endif %}
     "redis_sentinel_name": "{{ mountpoint.redis_sentinel_name | default(oiofs_mountpoint_default_redis_sentinel_name) }}",
     "redis_sentinel_server": {{ mountpoint.redis_sentinel_cluster | default(oiofs_mountpoint_default_redis_sentinel_cluster) | to_json }},
     "retry_delay": {{ mountpoint.retry_delay | default(oiofs_mountpoint_default_retry_delay) }}


### PR DESCRIPTION
- Fix json output configuration
- Only set recovery_cache_directory when specified to the mountpoint
- Renamed ansible-role-openio-gridinit to gridinit by default (can't use a var here ¿)