### PR TITLE
Adapt to config option renames

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,22 +69,22 @@ Each mountpoint to setup can specify the following members:
 | `cache_timeout` | `5` | Seconds between automatic cache flushes |
 | `chunk_size` | `1048576` | Chunk size in bytes (only used at mkfs.oiofs time) |
 | `chunk_part_size` | `1048576` | Chunk part size in bytes (only useful if `recovery_cache_directory` is given |
-| `fuse_max_retry` | `10` | Maximum number of fuse retry attempts |
+| `fuse_max_retries` | `10` | Maximum number of fuse retry attempts |
 | `ignore_flush` | `true` | Ignore flushes |
 | `inode_by_container` | `65536` | Maximum number of inodes per container (only used at mkfs.oiofs time) |
 | `log_level` | `'NOTICE'` | NOTICE < INFO < DEBUG |
-| `max_flush_thread` | `10` | Maximum number of flusher threads |
+| `max_flush_threads` | `10` | Maximum number of flusher threads |
 | `max_packed_chunks` | `10` |  |
 | `max_redis_connections` | `30` | Maximum number of connections to redis cluster |
 | `on_die` | `'respawn'` | What to do when the service handling this mountpoint dies (see *Note 3* below for details) |
 | `recovery_cache_directory` | `` | Local recovery cache directory, if any is to be used |
 | `redis_sentinel_name` | `'{{ oiofs_mountpoint_default_namespace }}-master-1'` | As a redis-sentinel cluster can host multiple instances, use the one with this name (see *Notes 1 & 2* below for details) |
-| `redis_sentinel_cluster` | `` | List of strings: `['IP1:port1', 'IP2:port2', 'IP3:port3', ]` telling oiofs who are the redis-sentinel cluster members |
+| `redis_sentinel_servers` | `` | List of strings: `['IP1:port1', 'IP2:port2', 'IP3:port3', ]` telling oiofs who are the redis-sentinel cluster members |
 | `redis_server | `'127.0.0.1:6379'` | Single standalone redis server (see *Note 1* below for details) |
 | `retry_delay` | `500` |  |
 | `start_at_boot` | `true` | mount the FS at boot time by gridinit |
 | `stats_server` | `None` | Web service address to query for mountpoint statistics |
-| `upload_retry_delay` | `0` | Upload retry delay |
+| `sds_retry_delay` | `0` | SDS actions retry delay |
 
 *NOTE 1*: `redis_server` and `redis_sentinel_name` are mutually exclusive. You
 have to choose between a standalone redis server or a redis-sentinel cluster. In

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,14 +41,14 @@ oiofs_mountpoint_default_cache_size_on_flush_bytes: 1024000000
 oiofs_mountpoint_default_cache_timeout: 5
 oiofs_mountpoint_default_chunk_part_size: 1048576
 oiofs_mountpoint_default_ignore_flush: true
-oiofs_mountpoint_default_fuse_max_retry: 10
+oiofs_mountpoint_default_fuse_max_retries: 10
 oiofs_mountpoint_default_log_level: 'NOTICE'  # 'NOTICE' < 'INFO' < 'DEBUG'
-oiofs_mountpoint_default_max_flush_thread: 10
+oiofs_mountpoint_default_max_flush_threads: 10
 oiofs_mountpoint_default_max_packed_chunks: 10
 oiofs_mountpoint_default_max_redis_connections: 30
 oiofs_mountpoint_default_on_die: 'respawn'
 oiofs_mountpoint_default_redis_sentinel_name: '{{ oiofs_mountpoint_default_namespace }}-master-1'
 oiofs_mountpoint_default_redis_server: '127.0.0.1:6379'
 oiofs_mountpoint_default_retry_delay: 500
-oiofs_mountpoint_default_upload_retry_delay: 0
+oiofs_mountpoint_default_sds_retry_delay: 0
 ...

--- a/tasks/mountpoint_present.yml
+++ b/tasks/mountpoint_present.yml
@@ -10,18 +10,18 @@
 
 - name: 'Check given mountpoint redis config: not more than one'
   fail:
-    msg: 'You can only specify one of: `redis_server` or `redis_sentinel_cluster` per mountpoint'
+    msg: 'You can only specify one of: `redis_server` or `redis_sentinel_servers` per mountpoint'
   when:
     - mountpoint.redis_server is defined
-    - mountpoint.redis_sentinel_cluster is defined
+    - mountpoint.redis_sentinel_servers is defined
 
 - name: 'Check given mountpoint redis config: cluster cannot be empty'
   fail:
-    msg: 'If you specify a `redis_sentinel_cluster`, it cannot be empty'
+    msg: 'If you specify a `redis_sentinel_servers`, it cannot be empty'
   when:
     - mountpoint.redis_server is not defined
-    - mountpoint.redis_sentinel_cluster is defined
-    - (mountpoint.redis_sentinel_cluster | length) < 1
+    - mountpoint.redis_sentinel_servers is defined
+    - (mountpoint.redis_sentinel_servers | length) < 1
 
 - name: 'oiofs: Setup oiofs configuration'
   template:

--- a/templates/oiofs.cfg.j2
+++ b/templates/oiofs.cfg.j2
@@ -9,18 +9,18 @@
 {% if mountpoint.recovery_cache_directory is defined %}
     "chunk_part_size": {{ mountpoint.chunk_part_size | default(oiofs_mountpoint_default_chunk_part_size) | int | to_json }},
 {% endif %}
-    "fuse_max_retry": {{ mountpoint.fuse_max_retry | default(oiofs_mountpoint_default_fuse_max_retry) | int | to_json }},
+    "fuse_max_retries": {{ mountpoint.fuse_max_retries | default(oiofs_mountpoint_default_fuse_max_retries) | int | to_json }},
     "ignore_flush": {{ mountpoint.ignore_flush | default(oiofs_mountpoint_default_ignore_flush) | bool | to_json }},
     "log_level": "{{ mountpoint.log_level | default(oiofs_mountpoint_default_log_level) }}",
-    "max_flush_thread": {{ mountpoint.max_flush_thread | default(oiofs_mountpoint_default_max_flush_thread) | int | to_json }},
+    "max_flush_threads": {{ mountpoint.max_flush_threads | default(oiofs_mountpoint_default_max_flush_threads) | int | to_json }},
     "max_packed_chunks": {{ mountpoint.max_packed_chunks | default(oiofs_mountpoint_default_max_packed_chunks) | int | to_json }},
     "max_redis_connections": {{ mountpoint.max_redis_connections | default(oiofs_mountpoint_default_max_redis_connections) | int | to_json }},
 {% if mountpoint.recovery_cache_directory is defined %}
     "recovery_cache_directory": "{{ mountpoint.recovery_cache_directory }}",
 {% endif %}
-{% if mountpoint.redis_sentinel_cluster is defined %}
+{% if mountpoint.redis_sentinel_servers is defined %}
     "redis_sentinel_name": "{{ mountpoint.redis_sentinel_name | default(oiofs_mountpoint_default_redis_sentinel_name) }}",
-    "redis_sentinel_server": {{ mountpoint.redis_sentinel_cluster | to_json }},
+    "redis_sentinel_servers": {{ mountpoint.redis_sentinel_servers | to_json }},
 {% else %}
     "redis_server": "{{ mountpoint.redis_server | default(oiofs_mountpoint_default_redis_server) }}",
 {% endif %}
@@ -28,5 +28,5 @@
 {% if mountpoint.stats_server is defined %}
     "stats_server": "{{ mountpoint.stats_server }}",
 {% endif %}
-    "upload_retry_delay": {{ mountpoint.upload_retry_delay | default(oiofs_mountpoint_default_upload_retry_delay) | int | to_json }}
+    "sds_retry_delay": {{ mountpoint.sds_retry_delay | default(oiofs_mountpoint_default_sds_retry_delay) | int | to_json }}
 }


### PR DESCRIPTION
- fuse_max_retry => fuse_max_retries
- upload_retry_delay => sds_retry_delay
- max_flush_thread => max_flush_threads
- redis_sentinel_server => redis_sentinel_servers