### PR TITLE
Lint and unmount_auto by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,17 +22,19 @@ before_install:
   - git config remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
   - git fetch origin docker-tests
   - git worktree add docker-tests origin/docker-tests
-  - curl https://github.com/open-io/ansible-role-openio-gridinit/blob/master/library/gridinitcmd.py --create-dirs -o library/gridinitcmd.py
+  - curl https://github.com/open-io/ansible-role-openio-gridinit/blob/master/library/gridinitcmd.py \
+    --create-dirs -o library/gridinitcmd.py
   - sudo pip install --upgrade pip
   - sudo pip install ansible-lint yamllint
   - export IPVAGRANT=$(ip -o -4 addr list eth0 | awk '{print $4}' | cut -d/ -f1)
   - docker run -d --net=host -e OPENIO_IPADDR=${IPVAGRANT} openio/sds
   - export SDS_DOCKER_ID=$(docker ps -aq)
-  - while ! docker exec -ti ${SDS_DOCKER_ID} openio container create travis_container --oio-ns OPENIO --oio-account travis_project; do sleep 1; done
+  - docker exec -ti \
+    ${SDS_DOCKER_ID} openio container create travis_container --oio-ns OPENIO --oio-account travis_project
 
 script:
   - ansible-lint . -x ANSIBLE0016
-  - yamllint .
+  - yamllint -c .yamllint -s $(find . -type f ! -name ".travis.yml" -a -name "*.yml")
   - ./docker-tests/docker-tests.sh
   - SUT_ID=$(docker ps -qa | head -n 1) ./docker-tests/functional-tests.sh
 ...

--- a/.yamllint
+++ b/.yamllint
@@ -1,16 +1,17 @@
 ---
-ignore:
-  env/**/*
+ignore: |
+  roles
+  archives
 rules:
   braces:
     level: error
-    min-spaces-inside: 0
+    min-spaces-inside: 1
     max-spaces-inside: 1
     min-spaces-inside-empty: 0
     max-spaces-inside-empty: 0
   brackets:
     level: error
-    min-spaces-inside: 0
+    min-spaces-inside: 1
     max-spaces-inside: 1
     min-spaces-inside-empty: 0
     max-spaces-inside-empty: 0
@@ -55,7 +56,7 @@ rules:
   key-ordering: disable
   line-length:
     level: error
-    max: 999
+    max: 120
     allow-non-breakable-words: true
     allow-non-breakable-inline-mappings: false
   new-line-at-end-of-file: enable

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,7 +22,10 @@ oiofs_mountpoint_default_force_mkfs: false
 oiofs_mountpoint_default_user: 'root'
 oiofs_mountpoint_default_group: 'root'
 oiofs_mountpoint_default_mode: '0755'
-oiofs_mountpoint_default_fuse_options: ['default_permissions', 'allow_other']
+oiofs_mountpoint_default_fuse_options:
+  - default_permissions
+  - allow_other
+  - auto_unmount
 oiofs_mountpoint_default_fuse_flags: []
 oiofs_mountpoint_default_chunk_size: 1048576
 oiofs_mountpoint_default_inode_by_container: 65536
@@ -47,5 +50,4 @@ oiofs_mountpoint_default_redis_sentinel_name: '{{ oiofs_mountpoint_default_names
 oiofs_mountpoint_default_redis_server: '127.0.0.1:6379'
 oiofs_mountpoint_default_retry_delay: 500
 oiofs_mountpoint_default_upload_retry_delay: 0
-
 ...

--- a/tasks/mountpoint_present.yml
+++ b/tasks/mountpoint_present.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: 'oiofs: Setup SDS namespace configuration if not already present'
   template:
     src: "sds_ns.cfg.j2"
@@ -33,13 +32,25 @@
     mode: 0644
 
 - name: Check if OIOFS is already present in container
-  command: 'openio reference show {{ mountpoint.container | default(oiofs_mountpoint_default_container) }} --oio-account {{ mountpoint.account | default(oiofs_mountpoint_default_account) }} --oio-ns {{ mountpoint.namespace | default(oiofs_mountpoint_default_namespace) }} -c meta.oiofs_chunk_size'
+  command: "openio reference show {{ mountpoint.container | default(oiofs_mountpoint_default_container) }} \
+     --oio-account {{ mountpoint.account | default(oiofs_mountpoint_default_account) }} \
+     --oio-ns {{ mountpoint.namespace | default(oiofs_mountpoint_default_namespace) }} \
+     -c meta.oiofs_chunk_size"
   register: oiofs_mkfsed
   changed_when: false
-  ignore_errors: true
+  failed_when: false
 
 - name: "oiofs: Create the filesystem inside container"
-  shell: "mkfs.oiofs -C {{ openio_oiofs_conf_directory }}/{{ mountpoint_id }}.json -v {% if mountpoint.force_mkfs | default(oiofs_mountpoint_default_force_mkfs) %} -f {% endif %} -u {{ mountpoint.user | default(oiofs_mountpoint_default_user) }} -g {{ mountpoint.group | default(oiofs_mountpoint_default_group) }} -m {{ mountpoint.mode | default(oiofs_mountpoint_default_mode) }} -c {{ mountpoint.chunk_size | default(oiofs_mountpoint_default_chunk_size) }} -i  {{ mountpoint.inode_by_container | default(oiofs_mountpoint_default_inode_by_container) }} {{ mountpoint.namespace | default(oiofs_mountpoint_default_namespace) }}/{{ mountpoint.account | default(oiofs_mountpoint_default_account) }}/{{ mountpoint.container | default(oiofs_mountpoint_default_container) }}"
+  shell: "mkfs.oiofs -C {{ openio_oiofs_conf_directory }}/{{ mountpoint_id }}.json \
+    -v {% if mountpoint.force_mkfs | default(oiofs_mountpoint_default_force_mkfs) %} -f {% endif %} \
+    -u {{ mountpoint.user | default(oiofs_mountpoint_default_user) }} \
+    -g {{ mountpoint.group | default(oiofs_mountpoint_default_group) }} \
+    -m {{ mountpoint.mode | default(oiofs_mountpoint_default_mode) }} \
+    -c {{ mountpoint.chunk_size | default(oiofs_mountpoint_default_chunk_size) }} \
+    -i  {{ mountpoint.inode_by_container | default(oiofs_mountpoint_default_inode_by_container) }} \
+    {{ mountpoint.namespace | default(oiofs_mountpoint_default_namespace) }}/\
+    {{ mountpoint.account | default(oiofs_mountpoint_default_account) }}/\
+    {{ mountpoint.container | default(oiofs_mountpoint_default_container) }}"
   when: oiofs_mkfsed.rc != 0 or (mountpoint.force_mkfs | default(oiofs_mountpoint_default_force_mkfs))
 
 - name: 'oiofs: Ensure OpenIO oiofs mountpoint directory exists'
@@ -78,12 +89,20 @@
           state: 'present'
           type: oiofs
           configuration:
-            command: "oiofs-fuse -f {% for opt in (mountpoint.fuse_options | default(oiofs_mountpoint_default_fuse_options)) %} -o {{ opt }} {% endfor %} {% for flag in (mountpoint.fuse_flags | default(oiofs_mountpoint_default_fuse_flags)) %} {{ flag }} {% endfor %} --oiofs-config {{ openio_oiofs_conf_directory }}/{{ mountpoint_id }}.json --cache-action {{ mountpoint.cache_action | default(oiofs_mountpoint_default_cache_action) }} --oiofs-user-url {{ mountpoint.namespace | default(oiofs_mountpoint_default_namespace) }}/{{ mountpoint.account | default(oiofs_mountpoint_default_account) }}/{{ mountpoint.container | default(oiofs_mountpoint_default_container) }} {{ mountpoint.path }}"
+            command: "oiofs-fuse \
+              -f {% for opt in (mountpoint.fuse_options | default(oiofs_mountpoint_default_fuse_options)) %} \
+              -o {{ opt }} {% endfor %} \
+              {% for flag in (mountpoint.fuse_flags | default(oiofs_mountpoint_default_fuse_flags)) %} \
+              {{ flag }} {% endfor %} \
+              --oiofs-config {{ openio_oiofs_conf_directory }}/{{ mountpoint_id }}.json \
+              --cache-action {{ mountpoint.cache_action | default(oiofs_mountpoint_default_cache_action) }} \
+              --oiofs-user-url {{ mountpoint.namespace | default(oiofs_mountpoint_default_namespace) }}/\
+              {{ mountpoint.account | default(oiofs_mountpoint_default_account) }}/\
+              {{ mountpoint.container | default(oiofs_mountpoint_default_container) }} {{ mountpoint.path }}"
             enabled: true
             start_at_boot: '{{ mountpoint.start_at_boot | default(oiofs_mountpoint_default_start_at_boot) }}'
             on_die: respawn
             uid: "{{ mountpoint.user | default(oiofs_mountpoint_default_user) }}"
             gid: "{{ mountpoint.group | default(oiofs_mountpoint_default_group) }}"
             env_PATH: "/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
-
 ...


### PR DESCRIPTION
```
$ SUT_ID=c18d3971d5d8 ./docker-tests/functional-tests.sh
### Using BATS executable at: /usr/bin/bats
### Running test /home/cedric/git/customer-canal/ansible/oiofs/roles/oiofs/docker-tests/checks.bats
 ✓ Path is mounted
 ✓ gridinit resource is UP
 ✓ put a file into the volume
 ✓ Object is present on SDS
 ✓ delete the file
 ✓ Object is absent on SDS

6 tests, 0 failures
```