### PR TITLE
[WIP] Change `stats_server` option into `http_server` which is now mandatory

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Each mountpoint to setup can specify the following members:
 | `redis_server | `'127.0.0.1:6379'` | Single standalone redis server (see *Note 1* below for details) |
 | `retry_delay` | `500` | Delay before retrying after an error (in milliseconds) |
 | `start_at_boot` | `true` | mount the FS at boot time by gridinit |
-| `stats_server` | `None` | Web service address to query for mountpoint statistics |
+| `http_server` | `'127.0.0.1:8080'` | Web service address |
 | `sds_retry_delay` | `0` | SDS actions retry delay |
 
 The full documentation for these options is [here](https://github.com/open-io/oio-fs/blob/master/CONF.md).

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -58,6 +58,7 @@ oiofs_mountpoint_default_cache_size_bytes: 2048000000
 oiofs_mountpoint_default_cache_size_on_flush_bytes: 1024000000
 oiofs_mountpoint_default_cache_timeout: 5
 oiofs_mountpoint_default_chunk_part_size: 1048576
+oiofs_mountpoint_default_http_server: '127.0.0.1:8080'
 oiofs_mountpoint_default_ignore_flush: true
 oiofs_mountpoint_default_fuse_max_retries: 10
 oiofs_mountpoint_default_log_level: 'NOTICE'  # 'NOTICE' < 'INFO' < 'DEBUG'

--- a/templates/oiofs.cfg.j2
+++ b/templates/oiofs.cfg.j2
@@ -25,9 +25,7 @@
     "redis_server": "{{ mountpoint.redis_server | default(oiofs_mountpoint_default_redis_server) }}",
 {% endif %}
     "retry_delay": {{ mountpoint.retry_delay | default(oiofs_mountpoint_default_retry_delay) | int | to_json }},
-{% if mountpoint.stats_server is defined %}
-    "stats_server": "{{ mountpoint.stats_server }}",
-{% endif %}
+    "http_server": "{{ mountpoint.http_server | default(oiofs_mountpoint_default_http_server) }}",
     "sds_retry_delay": {{ mountpoint.sds_retry_delay | default(oiofs_mountpoint_default_sds_retry_delay) | int | to_json }},
     "syslog_prefix": "{{ mountpoint.namespace | default(oiofs_mountpoint_default_namespace) }},oiofs,{{ mountpoint_id }}",
 {% if mountpoint.active_mode is defined %}


### PR DESCRIPTION
See: https://github.com/open-io/oio-fs/commit/3a1afb6db1d5d13fac7d3cefb7fd68acb1bb2308