### PR TITLE
Change default sds_retry_delay to be strictly positive

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Each mountpoint to setup can specify the following members:
 | `retry_delay` | `500` | Delay before retrying after an error (in milliseconds) |
 | `start_at_boot` | `true` | mount the FS at boot time by gridinit |
 | `http_server` | `127.0.0.1:6999` | Web service address to query for mountpoint statistics |
-| `sds_retry_delay` | `0` | SDS actions retry delay |
+| `sds_retry_delay` | `500` | SDS actions retry delay |
 | `sync_ha` | `true` | To only flush to the "recovery_cache_directory" on sync you need to change this value (true by default) |
 | `full_cache_timeout` | `500` | Cache timeout |
 | `active_mode` | `` | Default service mode, used for high availability. Set to 'true' to be active by default or 'false' to disable by default |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -71,7 +71,7 @@ oiofs_mountpoint_default_on_die: 'respawn'
 oiofs_mountpoint_default_redis_sentinel_name: '{{ oiofs_mountpoint_default_namespace }}-master-1'
 oiofs_mountpoint_default_redis_server: '127.0.0.1:6379'
 oiofs_mountpoint_default_retry_delay: 500
-oiofs_mountpoint_default_sds_retry_delay: 0
+oiofs_mountpoint_default_sds_retry_delay: 500
 oiofs_mountpoint_default_sync_ha: true
 oiofs_mountpoint_default_full_cache_timeout: 500
 oiofs_mountpoint_default_http_server: '127.0.0.1:6999'


### PR DESCRIPTION
Since a change in oio-fs sds_retry_delay need to be strictly positive
https://github.com/open-io/oio-fs/pull/304/commits/82a8faa8a6b47abfa41c51527a7d93af0d0d05b4