### PR TITLE
BUGFIX/MINOR(oiofs): Remove a blank in oiofs cache directory

### DIFF
--- a/tasks/mountpoint_present.yml
+++ b/tasks/mountpoint_present.yml
@@ -97,7 +97,7 @@
 - name: 'oiofs: Ensure oiofs cache directory exists'
   file:
     path: "{{ mountpoint.cache_directory \
-      | default(oiofs_mountpoint_default_cache_directory) }} \
+      | default(oiofs_mountpoint_default_cache_directory) }}\
       /oiofs-cache-{{ mountpoint.namespace | default(oiofs_mountpoint_default_namespace) }}\
       -{{ mountpoint.account }}-{{ mountpoint.container }}"
     owner: root


### PR DESCRIPTION
 ##### ISSUE TYPE
- Bugfix

 ##### SUMMARY
Currently the role create a folder "/mnt/cache "

 ##### SCOPE (skeleton only)
- oiofs

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION