### PR TITLE
BUGFIX/MAJOR(oiofs): Fix the deletion of mounts

### DIFF
--- a/tasks/mountpoint_absent.yml
+++ b/tasks/mountpoint_absent.yml
@@ -1,9 +1,7 @@
 ---
 
 - name: "oiofs: Unmount filesystem (by stopping gridinit service)"
-  gridinitcmd:
-    name: "{{ mountpoint.namespace | default(oiofs_mountpoint_default_namespace) }}-oiofs-{{ mountpoint_id }}"
-    state: stop
+  command: "gridinit_cmd stop {{ mountpoint.namespace | default(oiofs_mountpoint_default_namespace) }}-oiofs-{{ mountpoint_id }}"
   ignore_errors: true
 
 - name: 'oiofs: Remove oiofs configuration files'
@@ -21,8 +19,9 @@
   register: _delete_files
 
 - name: "oiofs: Reload gridinit"
-  gridinitcmd:
-    state: reload
+  systemd:
+    name: gridinit
+    state: reloaded
   when: _delete_files is changed
 
 ...


### PR DESCRIPTION
 ##### SUMMARY

The module gridinit is undefined here

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
```
TASK [oiofs : oiofs: Unsetup mountpoint] ****************************************************************
Friday 17 May 2019  14:17:30 +0000 (0:00:00.099)       0:00:07.172 ************
fatal: [node4]: FAILED! => {"reason": "no action detected in task. This often indicates a misspelled module name, or incorrect module path.\n\nThe error appears to have been in '/home/cedric/git/ansible-playbook-openio-deployment/products/sds/roles/oiofs/tasks/mountpoint_absent.yml': line 3, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: \"oiofs: Unmount filesystem (by stopping gridinit service)\"\n  ^ here\nThis one looks easy to fix.  It seems that there is a value started\nwith a quote, and the YAML parser is expecting to see the line ended\nwith the same kind of quote.  For instance:\n\n    when: \"ok\" in result.stdout\n\nCould be written as:\n\n   when: '\"ok\" in result.stdout'\n\nOr equivalently:\n\n   when: \"'ok' in result.stdout\"\n"}
```