### PR TITLE
Add big_writes to default_fuse_options

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,6 +44,7 @@ oiofs_mountpoint_default_fuse_options:
   - default_permissions
   - allow_other
   - auto_unmount
+  - big_writes
 oiofs_mountpoint_default_fuse_flags: []
 oiofs_mountpoint_default_chunk_size: 104857600
 oiofs_mountpoint_default_inode_by_container: 65536


### PR DESCRIPTION
 ##### SUMMARY
big_writes changes the limit from 4KiB to 64KiB write syscall

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
Jira: OS-358