### PR TITLE
FEATURE(oiofs): Allow use of several disks for cache

### DIFF
--- a/tasks/mountpoint_present.yml
+++ b/tasks/mountpoint_present.yml
@@ -115,6 +115,20 @@
     state: directory
     mode: 0750
   tags: configure
+  when: mountpoint.cache_directory | default(oiofs_mountpoint_default_cache_directory) is string
+
+- name: 'oiofs: Ensure oiofs cache directory exists'
+  file:
+    path: "{{ item }}/oiofs-cache-{{ mountpoint.namespace | default(oiofs_mountpoint_default_namespace) }}\
+      -{{ mountpoint.account }}-{{ mountpoint.container }}"
+    owner: root
+    group: root
+    state: directory
+    mode: 0750
+  tags: configure
+  with_items: "{{ mountpoint.cache_directory | default(oiofs_mountpoint_default_cache_directory) }}"
+  when: mountpoint.cache_directory | default(oiofs_mountpoint_default_cache_directory) is not string
+
 
 - name: 'oiofs: Ensure oiofs cache recovery directory exists'
   file:

--- a/templates/oiofs.cfg.j2
+++ b/templates/oiofs.cfg.j2
@@ -2,7 +2,11 @@
     "attributes_timeout": {{ mountpoint.attributes_timeout | default(oiofs_mountpoint_default_attributes_timeout) | int | to_json }},
     "auto_retry": {{ mountpoint.auto_retry | default(oiofs_mountpoint_default_auto_retry) | bool | to_json }},
     "cache_asynchronous": {{ mountpoint.cache_asynchronous | default(oiofs_mountpoint_default_cache_asynchronous) | bool | to_json }},
+{% if mountpoint.cache_directory | default(oiofs_mountpoint_default_cache_directory) is string %}
     "cache_directory": "{{ mountpoint.cache_directory | default(oiofs_mountpoint_default_cache_directory) }}/oiofs-cache-{{ mountpoint.namespace | default(oiofs_mountpoint_default_namespace) }}-{{ mountpoint.account }}-{{ mountpoint.container}}",
+{% else %}
+    "cache_directory": {{ mountpoint.cache_directory | default(oiofs_mountpoint_default_cache_directory) | map('regex_replace', '(.*)', '\\1/oiofs-cache-' + mountpoint.namespace | default(oiofs_mountpoint_default_namespace) + '-' + mountpoint.account + '-' + mountpoint.container) | list | to_json }},
+{% endif %}
     "cache_size": {{ mountpoint.cache_size_bytes | default(oiofs_mountpoint_default_cache_size_bytes) | int | to_json }},
     "cache_size_for_flush_activation": {{ mountpoint.cache_size_for_flush_activation | default(oiofs_mountpoint_default_cache_size_for_flush_activation) | int | to_json }},
     "cache_size_on_flush": {{ mountpoint.cache_size_on_flush_bytes | default(oiofs_mountpoint_default_cache_size_on_flush_bytes) | int | to_json }},


### PR DESCRIPTION
 ##### SUMMARY

The feature allows to split cache on multiple disks

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
https://github.com/open-io/oio-fs/pull/353
OB-443

Output:
```patch
-"cache_directory": ["/mnt/cache2/oiofs-cache-JENKINS-MY_ACCOUNT1-MY_CONTAINER1", "/mnt/cache1/oiofs-cache-JENKINS-MY_ACCOUNT1-MY_CONTAINER1"],
+"cache_directory": "/mnt/cache/oiofs-cache-JENKINS-MY_ACCOUNT1-MY_CONTAINER1",
```