### PR TITLE
BUMP(oiofs): CI - Set requirements.yml to `19.10`

### DIFF
--- a/docker-tests/requirements.yml
+++ b/docker-tests/requirements.yml
@@ -1,13 +1,13 @@
 ---
 - src: https://github.com/open-io/ansible-role-openio-repository.git
-  version: "19.04"
+  version: "19.10"
   name: repo
 
 - src: https://github.com/open-io/ansible-role-openio-gridinit.git
-  version: "19.04"
+  version: "19.10"
   name: gridinit
 
 - src: https://github.com/open-io/ansible-role-openio-users.git
-  version: "19.04"
+  version: "19.10"
   name: users
 ...

--- a/docker-tests/test.yml
+++ b/docker-tests/test.yml
@@ -13,7 +13,7 @@
       openio_repository_mirror_host: mirror2.openio.io
       openio_repository_products:
         oiofs:
-          release: "19.04"
+          release: "19.10"
           user: "{{ lookup('env','USR') }}"
           password: "{{ lookup('env','PASS') }}"
           #user: travisoiofs_id


### PR DESCRIPTION
 ##### SUMMARY

In order to be able to test the roles in `19.10`, it is necessary to change the branches in this file.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION